### PR TITLE
Patch/add excess to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Here is a template for new release sections
 ## [Unreleased]
 
 ### Added
--
+- `total_excess_annual_kWh` to list of output parameters. Calculation: `total_excess_annual_kWh = total_excess_ac_annual_kWh + total_excess_dc_annual` (#73)
 
 ### Changed
 -

--- a/src/C_sensitivity_experiments.py
+++ b/src/C_sensitivity_experiments.py
@@ -767,7 +767,7 @@ def overall_results_title(
                     "supply_reliability_kWh",
                     "res_share",
                     "autonomy_factor",
-                    "total_demand_excess_annual_kWh",
+                    "total_excess_annual_kWh",
                 ]
             ),
         ],

--- a/src/C_sensitivity_experiments.py
+++ b/src/C_sensitivity_experiments.py
@@ -767,6 +767,7 @@ def overall_results_title(
                     "supply_reliability_kWh",
                     "res_share",
                     "autonomy_factor",
+                    "total_demand_excess_annual_kWh",
                 ]
             ),
         ],

--- a/src/G3_oemof_evaluate.py
+++ b/src/G3_oemof_evaluate.py
@@ -164,7 +164,7 @@ def get_excess(
         ]
         excess += excess_ac
         annual_value(
-            "total_demand_excess_ac_annual_kWh", excess_ac, oemof_results, case_dict
+            "total_excess_ac_annual_kWh", excess_ac, oemof_results, case_dict
         )
         e_flows_df = join_e_flows_df(
             excess_ac, "Excess generation AC", e_flows_df
@@ -177,14 +177,14 @@ def get_excess(
         ]
         excess += excess_dc
         annual_value(
-            "total_demand_excess_dc_annual_kWh", excess, oemof_results, case_dict
+            "total_excess_dc_annual_kWh", excess, oemof_results, case_dict
         )  # not given as result.csv right now
         e_flows_df = join_e_flows_df(
             excess_dc, "Excess generation DC", e_flows_df
         )
 
     annual_value(
-        "total_demand_excess_annual_kWh", excess, oemof_results, case_dict
+        "total_excess_annual_kWh", excess, oemof_results, case_dict
     )  # not given as result.csv right now
     e_flows_df = join_e_flows_df(excess, "Excess generation", e_flows_df)
 


### PR DESCRIPTION
Fix #72 

Changed:
- Rename "total_demand_excess" to intuitive "total_excess"
- Add `total_excess_annual_kWh` to output parameters