### PR TITLE
Fix: Inverter capacity not displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ Here is a template for new release sections
 -
 
 ### Fixed
--
+- Typo when calling for the inverter capacity ('capacity_inverter_dc_ac_kW' and not 'capacity_inverter_kW'), (#75)
+
 
 ## [Offgridders V4.1] - 2020-05-01
 

--- a/src/C_sensitivity_experiments.py
+++ b/src/C_sensitivity_experiments.py
@@ -826,7 +826,7 @@ def overall_results_title(
                     "capacity_storage_kWh",
                     "power_storage_kW",
                     "capacity_rectifier_ac_dc_kW",
-                    "capacity_inverter_kW",
+                    "capacity_inverter_dc_ac_kW",
                     "capacity_wind_kW",
                     "capacity_genset_kW",
                     "capacity_pcoupling_kW",


### PR DESCRIPTION
Fix #71 

Changed:
- Fix typo when calling for the inverter capacity (`capacity_inverter_dc_ac_kW` and not `capacity_inverter_kW`)